### PR TITLE
fix: add null check for invalid field number in FieldsReader::doc

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+lucene++ (3.0.8-deepin6) unstable; urgency=medium
+
+  * Add null check for field number in FieldsReader::doc to prevent
+    crashes on corrupted index files with invalid field numbers.
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Tue, 16 Jun 2026 17:04:14 +0800
+
 lucene++ (3.0.8-deepin5) unstable; urgency=medium
 
   * Add N-Gram analyzer components.

--- a/debian/patches/fieldsreader-doc-null-check.patch
+++ b/debian/patches/fieldsreader-doc-null-check.patch
@@ -1,0 +1,14 @@
+Index: luceneplusplus/src/core/index/FieldsReader.cpp
+===================================================================
+--- luceneplusplus.orig/src/core/index/FieldsReader.cpp
++++ luceneplusplus/src/core/index/FieldsReader.cpp
+@@ -168,6 +168,9 @@ DocumentPtr FieldsReader::doc(int32_t n,
+     for (int32_t i = 0; i < numFields; ++i) {
+         int32_t fieldNumber = fieldsStream->readVInt();
+         FieldInfoPtr fi = fieldInfos->fieldInfo(fieldNumber);
++        if (!fi) {
++            boost::throw_exception(CorruptIndexException(L"invalid field number " + StringUtils::toString(fieldNumber) + L" while reading stored fields for doc " + StringUtils::toString(n)));
++        }
+         FieldSelector::FieldSelectorResult acceptField = fieldSelector ? fieldSelector->accept(fi->name) : FieldSelector::SELECTOR_LOAD;
+ 
+         uint8_t bits = fieldsStream->readByte();

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -12,3 +12,4 @@ fix-crash-when-reading-corrupted-or-incompatible-index-files
 fix-file-enumeration-exception.patch
 feat-cancel-search.patch
 feat-add-ngram-components.patch
+fieldsreader-doc-null-check.patch


### PR DESCRIPTION
Add a null pointer check for FieldInfoPtr when reading stored fields to prevent crashes when encountering corrupted index files with invalid field numbers. Throws CorruptIndexException with diagnostic information.

修复 FieldsReader::doc 中 field number 的空指针检查，当读取损坏的索引 文件时若遇到无效的 field number 则抛出 CorruptIndexException 异常。

Log: 修复 FieldsReader::doc 读取损坏索引时的空指针崩溃

Fixes: #366563